### PR TITLE
chore: apply NVIDIA SPDX license headers via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
 # SPDX-FileCopyrightText / SPDX-License-Identifier block; the year range is
 # derived from git history and auto-bumped on edit.
 - repo: https://github.com/rapidsai/pre-commit-hooks
-  rev: v1.4.3
+  rev: v1.5.0
   hooks:
     - id: verify-copyright
       args: [--fix, --spdx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
 # SPDX-FileCopyrightText / SPDX-License-Identifier block; the year range is
 # derived from git history and auto-bumped on edit.
 - repo: https://github.com/rapidsai/pre-commit-hooks
-  rev: v1.5.0
+  rev: v1.5.1
   hooks:
     - id: verify-copyright
       args: [--fix, --spdx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# License-header enforcement via pre-commit + rapidsai/pre-commit-hooks.
+#
+# Install locally with:
+#     pip install pre-commit && pre-commit install
+#
+# Run on all files (bulk update):
+#     PRE_COMMIT_HOME=$TMPDIR/pre-commit-cache pre-commit run strip-legacy-license-header --all-files
+#     PRE_COMMIT_HOME=$TMPDIR/pre-commit-cache pre-commit run verify-copyright --all-files
+
+repos:
+
+# Remove any leftover legacy HEAVY.AI/OmniSci/MapD header BEFORE verify-copyright
+# runs, so the NVIDIA SPDX header replaces it rather than stacking on top of it.
+- repo: local
+  hooks:
+    - id: strip-legacy-license-header
+      name: strip legacy HEAVY.AI/OmniSci/MapD license headers
+      entry: python3 scripts/strip_legacy_license_header.py
+      language: system
+      files: &license_files |
+        (?x)
+          [.](sh|py)$
+
+# Insert/maintain the NVIDIA SPDX header. --spdx emits the two-line
+# SPDX-FileCopyrightText / SPDX-License-Identifier block; the year range is
+# derived from git history and auto-bumped on edit.
+- repo: https://github.com/rapidsai/pre-commit-hooks
+  rev: v1.4.3
+  hooks:
+    - id: verify-copyright
+      args: [--fix, --spdx]
+      files: *license_files

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 NVIDIA Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security
+
+## Reporting Security Issues
+
+> [!WARNING]
+> Do not report security vulnerabilities through public GitHub issues!
+
+Instead, please submit a private vulnerability report, see below.
+
+## Reporting a Vulnerability
+
+1. **NVIDIA Vulnerability Disclosure Program (preferred)**
+   Submit through the NVIDIA Product Security Incident Response Team (PSIRT) web form (<https://www.nvidia.com/en-us/security/report-vulnerability/>)
+   This is the fastest path to triage and tracking.
+
+2. **Email NVIDIA PSIRT**
+   `psirt@nvidia.com` — encrypt sensitive reports with the
+   [NVIDIA PSIRT PGP key](https://www.nvidia.com/en-us/security/pgp-key).
+
+3. **GitHub Private Vulnerability Reporting**
+   Use the **Security and quality** tab on this repository → *Report a vulnerability*.
+
+## Report Details
+
+We prefer all communications to be in English.
+
+Reports should include the following:
+
+* reproducible example showing how the vulnerability can be exploited
+* statement about the impact (including affected versions)
+
+And we'd appreciate if they also include:
+
+* statement about whether you are interested in implementing the fix yourself
+
+## Disclosure Policy
+
+NVIDIA PSIRT will acknowledge receipt and coordinate triage, fix development, and coordinated disclosure.
+
+More on NVIDIA's response process: <https://www.nvidia.com/en-us/security/psirt-policies/>.

--- a/checkEnv.sh
+++ b/checkEnv.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 # Define colors for output
 GREEN='\033[0;32m'

--- a/configureHeavy.sh
+++ b/configureHeavy.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 # Reading .env file or setting defaults
 if [ -f ./.env ]; then

--- a/nvidiaDriver1.sh
+++ b/nvidiaDriver1.sh
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # !/bin/bash
 #  This script simply configurs Nvidia drivers in a typical Linux environment.  
 

--- a/nvidiaRuntime2.sh
+++ b/nvidiaRuntime2.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Script to configure Nvidia drivers and set up Nvidia container toolkit
 
 nvidia_docker_toolkit() {

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run the license-header pre-commit hooks against the files changed relative to a
+# base ref. Used both by CI (.github/workflows/pr-required-checks.yml) and locally:
+#
+#     scripts/check_license_headers.sh                # compare against origin/master
+#     scripts/check_license_headers.sh upstream/master # compare against another ref
+#
+# With --fix, modifications are applied to the working tree; without it the hooks
+# still apply fixes but a non-zero exit means a changed file was missing/outdated.
+set -euo pipefail
+
+BASE_REF="${1:-${GITHUB_BASE_REF:-master}}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Resolve the base ref to a concrete commit, fetching it if needed (shallow CI clones).
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  git fetch --quiet origin "${BASE_REF}:${BASE_REF}" 2>/dev/null \
+    || git fetch --quiet origin "${BASE_REF}" 2>/dev/null || true
+fi
+FROM_REF="$(git merge-base "${BASE_REF}" HEAD 2>/dev/null || echo "${BASE_REF}")"
+
+# verify-copyright derives "what changed" from the target branch; make it explicit so
+# this works under workflow_dispatch (where GITHUB_BASE_REF is unset) and locally.
+export TARGET_BRANCH="${BASE_REF}"
+
+echo "Checking license headers on files changed since ${FROM_REF} (base: ${BASE_REF})"
+exec pre-commit run --from-ref "${FROM_REF}" --to-ref HEAD --show-diff-on-failure

--- a/scripts/strip_legacy_license_header.py
+++ b/scripts/strip_legacy_license_header.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Strip legacy HEAVY.AI / OmniSci / MapD Apache-2.0 license headers.
+
+This is a companion fixer for the ``rapidsai/pre-commit-hooks`` ``verify-copyright``
+hook. ``verify-copyright`` only recognizes *NVIDIA* copyright lines, so on a file that
+still carries the old HEAVY.AI block it would *insert* an NVIDIA SPDX header while
+leaving the legacy block in place (two stacked headers). Running this fixer *before*
+``verify-copyright`` removes the recognized legacy block so the result is a single,
+clean NVIDIA SPDX header.
+
+It is intentionally conservative: it only removes a *leading* comment block that
+contains both a legacy copyright line and the Apache-2.0 boilerplate, so it never
+touches unrelated leading comments or genuine third-party headers (e.g. Simba,
+Apache Calcite). Run it standalone or via pre-commit:
+
+    python3 scripts/strip_legacy_license_header.py path/to/File.cpp ...
+
+Exits non-zero if any file was modified (pre-commit fixer convention).
+"""
+
+import re
+import sys
+
+# A legacy header is identified by a copyright line naming a legacy entity.
+# The Apache boilerplate is NOT required — short-form copyright-only blocks
+# (common in EE files) are also stripped.
+COPYRIGHT_RE = re.compile(
+    r"Copyright\s+\d{4}\s+(?:HEAVY\.AI|Heavy\.AI|OmniSci|MapD)", re.IGNORECASE
+)
+
+# Leading C-style /* ... */ block (optionally preceded by blank lines).
+C_BLOCK_RE = re.compile(r"\A(?:[ \t]*\r?\n)*[ \t]*/\*.*?\*/[ \t]*\r?\n?", re.DOTALL)
+# Leading run of #-comment lines.
+HASH_BLOCK_RE = re.compile(r"\A(?:[ \t]*#[^\n]*\r?\n)+")
+SHEBANG_RE = re.compile(r"\A#![^\n]*\r?\n")
+# #pragma once: preserve as a prefix so verify-copyright places the SPDX header before it.
+PRAGMA_ONCE_RE = re.compile(r"\A#pragma once[ \t]*\r?\n")
+# Blank lines to skip after shebang / #pragma once before the copyright block.
+LEADING_BLANK_RE = re.compile(r"\A(?:[ \t]*\r?\n)+")
+
+
+def strip_header(text: str) -> str:
+    """Return ``text`` with a leading legacy license block removed, if present."""
+    prefix = ""
+    body = text
+
+    # Preserve a shebang line so we only inspect the comment block after it.
+    shebang = SHEBANG_RE.match(body)
+    if shebang:
+        prefix = body[: shebang.end()]
+        body = body[shebang.end() :]
+
+    # Preserve #pragma once (must remain first after any shebang).
+    pragma = PRAGMA_ONCE_RE.match(body)
+    if pragma:
+        prefix += body[: pragma.end()]
+        body = body[pragma.end() :]
+
+    # Skip blank lines between prefix and the copyright comment block.
+    blank = LEADING_BLANK_RE.match(body)
+    body_after_blank = body[blank.end() :] if blank else body
+
+    for block_re in (C_BLOCK_RE, HASH_BLOCK_RE):
+        match = block_re.match(body_after_blank)
+        if not match:
+            continue
+        block = match.group(0)
+        if COPYRIGHT_RE.search(block):
+            rest = body_after_blank[match.end() :]
+            # Drop blank lines left behind between the old header and the code.
+            rest = re.sub(r"\A(?:[ \t]*\r?\n)+", "", rest)
+            return prefix + rest
+        # Only the first leading block is a candidate; stop after checking it.
+        break
+
+    return text
+
+
+def main(argv: list[str]) -> int:
+    changed = False
+    for path in argv:
+        try:
+            # utf-8-sig transparently strips a leading UTF-8 BOM if present.
+            with open(path, encoding="utf-8-sig") as f:
+                original = f.read()
+        except (OSError, UnicodeDecodeError):
+            # Binary or unreadable file; nothing to strip.
+            continue
+
+        updated = strip_header(original)
+        if updated != original:
+            # Always write back as plain UTF-8 (no BOM).
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(updated)
+            print(f"stripped legacy license header: {path}")
+            changed = True
+
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/templates/jupyterConfig/jupyterhub_config.py
+++ b/templates/jupyterConfig/jupyterhub_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` + `scripts/strip_legacy_license_header.py` to enforce NVIDIA SPDX license headers going forward
- Bulk-applies NVIDIA SPDX headers to all existing source files (replaces legacy HEAVY.AI/OmniSci/MapD headers; adds headers to files that previously had none)
- Part of the org-wide SPDX header rollout (see [heavydb-internal#8287](https://github.com/heavyai/heavydb-internal/pull/8287))

## Test plan
- [x] `pre-commit run verify-copyright --all-files` reports no changes after this PR lands — **verified 2026-06-11**
- [ ] Follow-on PRs that touch source files get headers enforced automatically